### PR TITLE
Fix incorrect table definition for ProductCategory model in Sequelize

### DIFF
--- a/api/src/models/ProductCategory.ts
+++ b/api/src/models/ProductCategory.ts
@@ -1,10 +1,21 @@
 'use strict';
 import { Model } from "sequelize";
-
+import Product from './Product';
+import Category from './Category';
 
 export default (sequelize: any, DataTypes: any) => {
     class ProductCategory extends Model {
-        static associate(models: any) {}
+        static associate(models: any) {
+            ProductCategory.belongsTo(models.Product, {
+                foreignKey: 'productId',
+                as: 'product'
+            });
+
+            ProductCategory.belongsTo(models.Category, {
+                foreignKey: 'categoryId',
+                as: 'category'
+            });
+        }
     }
 
     ProductCategory.init({


### PR DESCRIPTION
Ajuste en la definición de la tabla intermedia de productos y categorías para incluir referencias a las tablas primarias correspondientes.



